### PR TITLE
Change ConkyWriter to a 'New-Style' Class.

### DIFF
--- a/conkyutil/writer.py
+++ b/conkyutil/writer.py
@@ -3,7 +3,7 @@ import sys
 
 from os.path import join as pjoin, exists
 
-class ConkyWriter:
+class ConkyWriter(object):
     """ ConkyWriter class allows to wrap all conky command to python method. """
 
     def __init__(self, stream=sys.stdout):


### PR DESCRIPTION
Changing ConkyWriter to a [New-Style Class](https://www.python.org/doc/newstyle/) allows me to inherit it like this:

```
class ConkyWeatherWriter(ConkyWriter):
    
    def __init__(self, conky_weather):
        super(ConkyWeatherWriter, self).__init__()
        ...
```